### PR TITLE
Migrate from master and slave lingo

### DIFF
--- a/cmdb/rest/migrations/0001_initial.py
+++ b/cmdb/rest/migrations/0001_initial.py
@@ -198,7 +198,7 @@ class Migration(migrations.Migration):
             name='DbService',
             fields=[
                 ('baseservice_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='rest.BaseService')),
-                ('use_type', models.CharField(choices=[('shard', 'shard'), ('master-slave', 'master-slave'), ('pxc', 'pxc')], max_length=255)),
+                ('use_type', models.CharField(choices=[('shard', 'shard'), ('main-subordinate', 'main-subordinate'), ('pxc', 'pxc')], max_length=255)),
             ],
             options={
                 'verbose_name': 'db-service',

--- a/cmdb/rest/migrations/0004_auto_20190429_1430.py
+++ b/cmdb/rest/migrations/0004_auto_20190429_1430.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                 ('rght', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('tree_id', models.PositiveIntegerField(db_index=True, editable=False)),
                 ('level', models.PositiveIntegerField(db_index=True, editable=False)),
-                ('use_type', models.CharField(choices=[('shard', 'shard'), ('master-slave', 'master-slave'), ('pxc', 'pxc')], max_length=255)),
+                ('use_type', models.CharField(choices=[('shard', 'shard'), ('main-subordinate', 'main-subordinate'), ('pxc', 'pxc')], max_length=255)),
                 ('history_id', models.AutoField(primary_key=True, serialize=False)),
                 ('history_date', models.DateTimeField()),
                 ('history_change_reason', models.CharField(max_length=100, null=True)),


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.